### PR TITLE
LOONGARCH64: Use  __loongarch_lp64 instead of _ABILP64

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -560,7 +560,7 @@
 #undef LJ_TARGET_MIPS
 #endif
 #elif LJ_TARGET_LOONGARCH64
-#if !(defined(_ABILP64) && _LOONGARCH_SIM == _ABILP64)
+#if !defined(__loongarch_lp64)
 #error "Only LOONGARCH lp64d ABI is supported"
 #undef LJ_TARGET_LOONGARCH64
 #endif


### PR DESCRIPTION
_ABILP64 is a legacy macro definition, which is not supported in all compilers. It should use the macro definition __loongarch_lp64 specified in spec [1].

[1]: https://github.com/loongson/la-toolchain-conventions